### PR TITLE
NO-JIRA 배포를 위한 Draft release note workflow 를 추가해요

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,30 @@
+name-template: "🚀 $RESOLVED_VERSION"
+tag-template: "$RESOLVED_VERSION"
+categories:
+  - title: "✨ Features"
+    label: "Feature"
+
+  - title: "😎 Update"
+    label: "Update"
+
+  - title: "🐛 Bug Fixes"
+    label: "Bug"
+
+  - title: "🤓 Improvements"
+    label: "Improvement"
+
+  - title: "📚 Documentation"
+    label: "Docs"
+
+  - title: "🧰 Maintenance"
+    labels:
+      - "CI"
+
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: '\<*_&'
+template: |
+  ## What’s Changed
+
+  $CHANGES
+
+  ## What's Included

--- a/.github/workflows/draft-release-note.yml
+++ b/.github/workflows/draft-release-note.yml
@@ -1,0 +1,20 @@
+name: Draft Release Note
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  draft-release-note:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: release-drafter/release-drafter@v5
+        with:
+          version: ${{ inputs.version_tag || github.ref_name }}
+          footer: "${{ steps.component_version_table.outputs.markdown }}"
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 배경

- 배포를 위한 Draft release note workflow 를 추가해요

## 수정 내역

- draft release note workflow 추가

## 테스트 방법

- 태그 생성