### PR TITLE
MBP-4282 CollectionViewAdpater 내부에 불필요한 로직을 제거해요

### DIFF
--- a/Sources/KarrotListKit/Adapter/CollectionViewAdapter.swift
+++ b/Sources/KarrotListKit/Adapter/CollectionViewAdapter.swift
@@ -288,8 +288,6 @@ extension CollectionViewAdapter: UICollectionViewDelegate {
     willDisplay cell: UICollectionViewCell,
     forItemAt indexPath: IndexPath
   ) {
-    guard cell.isValidSize() else { return }
-
     guard let item = item(at: indexPath) else {
       return
     }
@@ -312,8 +310,6 @@ extension CollectionViewAdapter: UICollectionViewDelegate {
     didEndDisplaying cell: UICollectionViewCell,
     forItemAt indexPath: IndexPath
   ) {
-    guard cell.isValidSize() else { return }
-
     guard let item = item(at: indexPath) else {
       return
     }
@@ -333,8 +329,6 @@ extension CollectionViewAdapter: UICollectionViewDelegate {
     forElementKind elementKind: String,
     at indexPath: IndexPath
   ) {
-    guard view.isValidSize() else { return }
-
     guard let section = sectionItem(at: indexPath.section) else {
       return
     }
@@ -373,8 +367,6 @@ extension CollectionViewAdapter: UICollectionViewDelegate {
     forElementOfKind elementKind: String,
     at indexPath: IndexPath
   ) {
-    guard view.isValidSize() else { return }
-
     guard let section = sectionItem(at: indexPath.section) else {
       return
     }
@@ -488,22 +480,6 @@ extension CollectionViewAdapter: UICollectionViewDataSourcePrefetching {
       }
     }
   }
-}
-
-extension UIView {
-
-  fileprivate func isValidSize() -> Bool {
-    if frame.height == 0.0 {
-      return false
-    }
-
-    if frame.width == 0.0 {
-      return false
-    }
-
-    return true
-  }
-
 }
 
 // MARK: - UICollectionViewDataSource


### PR DESCRIPTION
## 배경

- [MBP-4282](https://karrot.atlassian.net/browse/MBP-4282)

## 수정 내역

- 이전에 DiffableDataSource 사용하면서 iOS 14.X에서 발생했던 문제로 들어간 코드를 제거해요.

## 테스트 방법

- 빌드 테스트

## 리뷰 노트

- 없어요!


[MBP-4282]: https://karrot.atlassian.net/browse/MBP-4282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ