### PR TITLE
NO-JIRA README 의 DocC 문서 링크를 수정해요

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ Now you're ready to start using the KarrotListKit Framework
 
 
 ## Getting Started
-
-[API documentation](https://fluffy-couscous-5mql18j.pages.github.io/documentation/karrotlistkit) provides that see detailed description of each type 
+See the [KarrotListKit DocC documentation](https://swiftpackageindex.com/daangn/KarrotListKit/main/documentation/karrotlistkit) hosted on the [Swift Package Index](https://swiftpackageindex.com/).
 
 ### CollectionViewAdapter
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-## Introduction
-
+# KarrotListKit
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fdaangn%2FKarrotListKit%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/daangn/KarrotListKit)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fdaangn%2FKarrotListKit%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/daangn/KarrotListKit)
 Welcome to our Karrot Listing Framework. This powerful tool is developed with UIKit, but it is designed to be used like a declarative UI API, providing a seamless transition to SwiftUI and reducing migration costs.
 
 Our framework is built with an optimized diffing algorithm, thanks to its dependency on [DifferenceKit](https://github.com/ra1028/DifferenceKit). This ensures high performance and swift rendering of your lists, allowing your application to run smoothly, even when handling large changes of data.


### PR DESCRIPTION
## 배경

- Swift Package Index 를 활용해 호스팅하도록 수정해요.
- https://swiftpackageindex.com/daangn/KarrotListKit/main/documentation/karrotlistkit
- 문서 배치가 도는 시점에 병합할 예정이에요

## 수정 내역

- README 수정