### PR TITLE
[Support] If the header or footer is absent, a guide assertion failure occurs.

### DIFF
--- a/Sources/KarrotListKit/Section.swift
+++ b/Sources/KarrotListKit/Section.swift
@@ -175,6 +175,9 @@ extension Section {
   @discardableResult
   public func willDisplayHeader(_ handler: @escaping (WillDisplayEvent.EventContext) -> Void) -> Self {
     var copy = self
+    if header == nil {
+      assertionFailure("Please declare the header first using [withHeader]")
+    }
     copy.header = header?.willDisplay(handler)
     return copy
   }
@@ -186,6 +189,9 @@ extension Section {
   @discardableResult
   public func willDisplayFooter(_ handler: @escaping (WillDisplayEvent.EventContext) -> Void) -> Self {
     var copy = self
+    if footer == nil {
+      assertionFailure("Please declare the footer first using [withFooter]")
+    }
     copy.footer = footer?.willDisplay(handler)
     return copy
   }
@@ -196,6 +202,9 @@ extension Section {
   ///  - handler: The callback handler when the header is removed from the screen.
   public func didEndDisplayHeader(_ handler: @escaping (DidEndDisplayingEvent.EventContext) -> Void) -> Self {
     var copy = self
+    if header == nil {
+      assertionFailure("Please declare the header first using [withHeader]")
+    }
     copy.header = header?.didEndDisplaying(handler)
     return copy
   }
@@ -206,6 +215,9 @@ extension Section {
   ///  - handler: The callback handler when the footer is removed from the screen.
   public func didEndDisplayFooter(_ handler: @escaping (DidEndDisplayingEvent.EventContext) -> Void) -> Self {
     var copy = self
+    if footer == nil {
+      assertionFailure("Please declare the footer first using [withFooter]")
+    }
     copy.footer = footer?.didEndDisplaying(handler)
     return copy
   }


### PR DESCRIPTION
## 배경

API declaration order is important when configuring header and footer, but there is a possibility of human error.

❌ 
```swift
    .willDisplayHeader {
      ...
    }
    .withHeader(
      Some()
    )
```

⭕ 
```swift
    .withHeader(
      Some()
    )
    .willDisplayHeader {
      ...
    }
```

- So, If the header or footer is absent, a guide assertion failure occurs.

## 수정 내역

- support footer & header configuration guide assertion failrue

## 테스트 방법

- no test

## 리뷰 노트

- nope
