### PR TITLE
MBP-6915 Adapter apply 인터페이스 개선

### DIFF
--- a/Sources/KarrotListKit/Adapter/CollectionViewAdapterUpdateStrategy.swift
+++ b/Sources/KarrotListKit/Adapter/CollectionViewAdapterUpdateStrategy.swift
@@ -1,0 +1,26 @@
+//
+//  Copyright (c) 2024 Danggeun Market Inc.
+//
+
+import Foundation
+
+/// The approaches for updating the content of a `UICollectionView`.
+public enum CollectionViewAdapterUpdateStrategy {
+  
+  /// Performs animated batch updates by calling `performBatchUpdates(…)` with the new content.
+  case animatedBatchUpdates
+
+  /// Performs non-animated batch updates by wrapping a call to `performBatchUpdates(…)` with the
+  /// new content within a `UIView.performWithoutAnimation(…)` closure.
+  ///
+  /// More performant than `reloadData`, as it does not recreate and reconfigure all visible
+  /// cells.
+  case nonanimatedBatchUpdates
+
+  /// Performs non-animated updates by calling `reloadData()`, which recreates and reconfigures
+  /// all visible cells.
+  ///
+  /// UIKit engineers have suggested that we should never need to call `reloadData` on updates,
+  /// and instead just use batch updates for all content updates.
+  case reloadData
+}


### PR DESCRIPTION
### Background
`CollectionViewAdapter`의 apply 함수 인터페이스를 개선해요.
apply시 `CollectionViewAdapterUpdateStrategy` 인자를 받는 함수를 추가했어요.

```swift
/// The approaches for updating the content of a `UICollectionView`.
public enum CollectionViewAdapterUpdateStrategy {
  
  /// Performs animated batch updates by calling `performBatchUpdates(…)` with the new content.
  case animatedBatchUpdates

  /// Performs non-animated batch updates by wrapping a call to `performBatchUpdates(…)` with the
  /// new content within a `UIView.performWithoutAnimation(…)` closure.
  ///
  /// More performant than `reloadData`, as it does not recreate and reconfigure all visible
  /// cells.
  case nonanimatedBatchUpdates

  /// Performs non-animated updates by calling `reloadData()`, which recreates and reconfigures
  /// all visible cells.
  ///
  /// UIKit engineers have suggested that we should never need to call `reloadData` on updates,
  /// and instead just use batch updates for all content updates.
  case reloadData
}
```