### PR TITLE
노출된 View 사이즈 캐시 로직을 구현해요.

### DIFF
--- a/Sources/KarrotListKit/Extension/UIView+TraitCollection.swift .swift
+++ b/Sources/KarrotListKit/Extension/UIView+TraitCollection.swift .swift
@@ -1,0 +1,27 @@
+//
+//  Copyright (c) 2025 Danggeun Market Inc.
+//
+
+import UIKit
+
+extension UIView {
+
+  func shouldInvalidateContentSize(
+    previousTraitCollection: UITraitCollection?
+  ) -> Bool {
+    if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
+      return true
+    }
+
+    if traitCollection.legibilityWeight != previousTraitCollection?.legibilityWeight {
+      return true
+    }
+
+    if traitCollection.horizontalSizeClass != previousTraitCollection?.horizontalSizeClass ||
+        traitCollection.verticalSizeClass != previousTraitCollection?.verticalSizeClass {
+      return true
+    }
+
+    return false
+  }
+}

--- a/Sources/KarrotListKit/FeatureFlag/DefaultFeatureFlagProvider.swift
+++ b/Sources/KarrotListKit/FeatureFlag/DefaultFeatureFlagProvider.swift
@@ -1,0 +1,12 @@
+//
+//  Copyright (c) 2025 Danggeun Market Inc.
+//
+
+import Foundation
+
+final class DefaultFeatureFlagProvider: FeatureFlagProviding {
+
+  func featureFlags() -> [FeatureFlagItem] {
+    []
+  }
+}

--- a/Sources/KarrotListKit/FeatureFlag/FeatureFlagItem.swift
+++ b/Sources/KarrotListKit/FeatureFlag/FeatureFlagItem.swift
@@ -1,0 +1,28 @@
+//
+//  Copyright (c) 2025 Danggeun Market Inc.
+//
+
+import Foundation
+
+/// Representing a feature flag item.
+public struct FeatureFlagItem {
+
+  /// The type of the feature flag.
+  public let type: FeatureFlagType
+
+  /// A Boolean value indicating whether the feature flag is enabled.
+  public let isEnabled: Bool
+
+  /// Initializes a new `FeatureFlagItem`.
+  ///
+  /// - Parameters:
+  ///   - type: The type of the feature flag.
+  ///   - isEnabled: A Boolean value indicating whether the feature flag is enabled.
+  public init(
+    type: FeatureFlagType,
+    isEnabled: Bool
+  ) {
+    self.type = type
+    self.isEnabled = isEnabled
+  }
+}

--- a/Sources/KarrotListKit/FeatureFlag/FeatureFlagProviding.swift
+++ b/Sources/KarrotListKit/FeatureFlag/FeatureFlagProviding.swift
@@ -1,0 +1,23 @@
+//
+//  Copyright (c) 2025 Danggeun Market Inc.
+//
+
+import Foundation
+
+/// A protocol for providing feature flags.
+public protocol FeatureFlagProviding {
+
+  /// Returns an array of feature flags.
+  ///
+  /// - Returns: An array of `FeatureFlagItem`.
+  func featureFlags() -> [FeatureFlagItem]
+}
+
+extension FeatureFlagProviding {
+
+  func isEnabled(for type: FeatureFlagType) -> Bool {
+    featureFlags()
+      .first(where: { $0.type == type })?
+      .isEnabled ?? false
+  }
+}

--- a/Sources/KarrotListKit/FeatureFlag/FeatureFlagType.swift
+++ b/Sources/KarrotListKit/FeatureFlag/FeatureFlagType.swift
@@ -1,0 +1,13 @@
+//
+//  Copyright (c) 2025 Danggeun Market Inc.
+//
+
+import Foundation
+
+/// Define the feature flags
+public enum FeatureFlagType: Equatable {
+
+  /// Improve scrolling performance using calculated view size.
+  /// You can find more information at https://developer.apple.com/documentation/uikit/building-high-performance-lists-and-collection-views
+  case usesCachedViewSize
+}

--- a/Sources/KarrotListKit/FeatureFlag/KarrotListKitFeatureFlag.swift
+++ b/Sources/KarrotListKit/FeatureFlag/KarrotListKitFeatureFlag.swift
@@ -1,0 +1,15 @@
+//
+//  Copyright (c) 2025 Danggeun Market Inc.
+//
+
+import Foundation
+
+/// An interface for injecting a feature flag provider.
+public enum KarrotListKitFeatureFlag {
+
+  /// The feature flag provider used by `KarrotListKit`.
+  ///
+  /// By default, this is set to `DefaultFeatureFlagProvider`.
+  /// You can replace it with a custom provider to change the feature flag behavior.
+  public static var provider: FeatureFlagProviding = DefaultFeatureFlagProvider()
+}

--- a/Sources/KarrotListKit/View/UICollectionComponentReusableView.swift
+++ b/Sources/KarrotListKit/View/UICollectionComponentReusableView.swift
@@ -14,6 +14,8 @@ final class UICollectionComponentReusableView: UICollectionReusableView, Compone
 
   var onSizeChanged: ((CGSize) -> Void)?
 
+  private var previousBounds: CGSize = .zero
+
   // MARK: - Initializing
 
   @available(*, unavailable)
@@ -29,12 +31,41 @@ final class UICollectionComponentReusableView: UICollectionReusableView, Compone
 
   // MARK: - Override Methods
 
+  public override func traitCollectionDidChange(
+    _ previousTraitCollection: UITraitCollection?
+  ) {
+    super.traitCollectionDidChange(previousTraitCollection)
+
+    if shouldInvalidateContentSize(
+      previousTraitCollection: previousTraitCollection
+    ) {
+      previousBounds = .zero
+    }
+  }
+
+  public override func prepareForReuse() {
+    super.prepareForReuse()
+
+    previousBounds = .zero
+  }
+
+  public override func layoutSubviews() {
+    super.layoutSubviews()
+
+    previousBounds = bounds.size
+  }
+
   override func preferredLayoutAttributesFitting(
     _ layoutAttributes: UICollectionViewLayoutAttributes
   ) -> UICollectionViewLayoutAttributes {
     let attributes = super.preferredLayoutAttributesFitting(layoutAttributes)
 
     guard let renderedContent else {
+      return attributes
+    }
+
+    if KarrotListKitFeatureFlag.provider.isEnabled(for: .usesCachedViewSize),
+       previousBounds == attributes.size {
       return attributes
     }
 

--- a/Tests/KarrotListKitTests/FeatureFlagProviderTests.swift
+++ b/Tests/KarrotListKitTests/FeatureFlagProviderTests.swift
@@ -1,0 +1,46 @@
+//
+//  Copyright (c) 2025 Danggeun Market Inc.
+//
+
+import Foundation
+import XCTest
+
+@testable import KarrotListKit
+
+final class FeatureFlagProviderTests: XCTestCase {
+
+  final class FeatureFlagProviderStub: FeatureFlagProviding {
+
+    var featureFlagsStub: [FeatureFlagItem] = []
+
+    func featureFlags() -> [FeatureFlagItem] {
+      featureFlagsStub
+    }
+  }
+
+  func test_default_featureFlags_is_empty() {
+    // given
+    let sut = KarrotListKitFeatureFlag.provider
+
+    // when
+    let featureFlags = sut.featureFlags()
+
+    // then
+    XCTAssertTrue(featureFlags.isEmpty)
+  }
+
+  func test_usesCachedViewSize_isEnabled() {
+    [true, false].forEach { flag in
+      // given
+      let provider = FeatureFlagProviderStub()
+      provider.featureFlagsStub = [.init(type: .usesCachedViewSize, isEnabled: flag)]
+      KarrotListKitFeatureFlag.provider = provider
+
+      // when
+      let isEnabled = KarrotListKitFeatureFlag.provider.isEnabled(for: .usesCachedViewSize)
+
+      // then
+      XCTAssertEqual(isEnabled, flag)
+    }
+  }
+}


### PR DESCRIPTION
## 배경

- [Building high-performance lists and collection views](https://developer.apple.com/documentation/uikit/building-high-performance-lists-and-collection-views) sample project 내용을 참고하여 스크롤 성능을 개선해요.
- 이미 노출된 View도 `preferredLayoutAttributesFitting`가 여러번 호출될 수 있어요.
- 불필요한 호출로 성능이 저하될 수 있는 부분을 개선해요.

## 수정 내역

- feature flag를 적용하여 기능 on/off 가능하도록 해요.
- 이미 노출된 view 사이즈를 캐시하여 `preferredLayoutAttributesFitting` 비용을 낮춰요.


## 테스트 방법

- 로컬에서 앱 연동 테스트 진행