### PR TITLE
Use reconfigureItems instead of reloadItems

### DIFF
--- a/Sources/KarrotListKit/Adapter/CollectionViewAdapter.swift
+++ b/Sources/KarrotListKit/Adapter/CollectionViewAdapter.swift
@@ -210,7 +210,7 @@ final public class CollectionViewAdapter: NSObject {
       setData: { sections in
         list?.sections = sections
       },
-      enableReconfigure: configuration.enableReconfigureWhenUpdateItem,
+      enablesReconfigureItems: configuration.enablesReconfigureItems,
       completion: completion
     )
   }

--- a/Sources/KarrotListKit/Adapter/CollectionViewAdapterConfiguration.swift
+++ b/Sources/KarrotListKit/Adapter/CollectionViewAdapterConfiguration.swift
@@ -23,22 +23,22 @@ public struct CollectionViewAdapterConfiguration {
   /// cells rather than recreating them.
   ///
   /// The default value is false.
-  public let enableReconfigureWhenUpdateItem: Bool
+  public let enablesReconfigureItems: Bool
 
   /// Initialize a new instance of `UICollectionViewAdapter`.
   ///
   /// - Parameters:
   ///   - refreshControl: RefreshControl of the CollectionView
   ///   - batchUpdateInterruptCount: maximum changeSet count that can be animated updates
-  ///   - enableReconfigureWhenUpdateItem: whether to use reconfigureItems API for item updates
+  ///   - enablesReconfigureItems: whether to use reconfigureItems API for item updates
   public init(
     refreshControl: RefreshControl = .disabled(),
     batchUpdateInterruptCount: Int = 100,
-    enableReconfigureWhenUpdateItem: Bool = false
+    enablesReconfigureItems: Bool = false
   ) {
     self.refreshControl = refreshControl
     self.batchUpdateInterruptCount = batchUpdateInterruptCount
-    self.enableReconfigureWhenUpdateItem = enableReconfigureWhenUpdateItem
+    self.enablesReconfigureItems = enablesReconfigureItems
   }
 }
 

--- a/Sources/KarrotListKit/Extension/UICollectionView+Difference.swift
+++ b/Sources/KarrotListKit/Extension/UICollectionView+Difference.swift
@@ -11,7 +11,7 @@ extension UICollectionView {
     using stagedChangeset: StagedChangeset<C>,
     interrupt: ((Changeset<C>) -> Bool)? = nil,
     setData: (C) -> Void,
-    enableReconfigure: Bool,
+    enablesReconfigureItems: Bool,
     completion: ((Bool) -> ())? = nil
   ) {
     if stagedChangeset.isEmpty {
@@ -66,7 +66,7 @@ extension UICollectionView {
         }
 
         if !changeset.elementUpdated.isEmpty {
-          if #available(iOS 15.0, *), enableReconfigure {
+          if #available(iOS 15.0, *), enablesReconfigureItems {
             reconfigureItems(at: changeset.elementUpdated.map { IndexPath(item: $0.element, section: $0.section) })
           } else {
             reloadItems(at: changeset.elementUpdated.map { IndexPath(item: $0.element, section: $0.section) })


### PR DESCRIPTION
Replace reloadItems with reconfigureItems when updating existing items so cells are updated in place without delete/insert.
This avoids unintended cell re-creation, preserves selection/animation state, and improves performance.